### PR TITLE
fix link

### DIFF
--- a/lecture_02.py
+++ b/lecture_02.py
@@ -85,7 +85,7 @@ def motivating_questions():
 
 def tensors_basics():
     text("Tensors are the basic building block for storing everything: parameters, gradients, optimizer state, data, activations.")
-    link("[PyTorch docs on tensors]", url="https://pytorch.org/docs/stable/tensors.html")
+    link(title="[PyTorch docs on tensors]", url="https://pytorch.org/docs/stable/tensors.html")
 
     text("You can create tensors in multiple ways:")
     x = torch.tensor([[1., 2, 3], [4, 5, 6]])  # @inspect x


### PR DESCRIPTION
It seems this PR will fix the broken link for `[PyTorch docs on tensors]`.

<img width="1052" alt="Screenshot 2025-04-06 at 12 43 08 PM" src="https://github.com/user-attachments/assets/1874b6c4-be80-4534-bfab-40500314efcb" />
